### PR TITLE
Add GitHub Actions workflow to update trophy

### DIFF
--- a/.github/workflows/update-trophy.yml
+++ b/.github/workflows/update-trophy.yml
@@ -1,0 +1,37 @@
+name: Update GitHub Profile Trophy
+
+on:
+  schedule:
+    # Runs every day at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allows manual trigger
+  push:
+    branches:
+      - main
+
+jobs:
+  update-trophy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        
+      - name: Generate Trophy
+        uses: soulteary/github-profile-trophy-action@main
+        with:
+          username: suraj-yadav0
+          theme: discord
+          column: 7
+          no-frame: false
+          output-path: assets/trophy.svg
+          
+      - name: Commit and Push Changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add assets/trophy.svg
+          git diff --quiet && git diff --staged --quiet || (git commit -m "🏆 Update GitHub Profile Trophy" && git push)


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the updating of the GitHub Profile Trophy SVG. The workflow is scheduled to run daily, can be triggered manually, and also runs on pushes to the `main` branch.

**Automation and CI/CD:**

* Added `.github/workflows/update-trophy.yml` to automatically generate and update the `assets/trophy.svg` file using the `soulteary/github-profile-trophy-action`, with scheduled, manual, and push triggers.